### PR TITLE
Fix format string deprecation, replace warn with print

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,9 +4,9 @@ const Pkg = std.build.Pkg;
 
 fn checkPackage(indexFile: []const u8, url: []const u8, ) void {
     std.fs.cwd().access(indexFile, std.fs.File.OpenFlags { .read = true }) catch |err| {
-        std.debug.warn("Error: library index file '{}' does not exist\n", .{indexFile});
+        std.debug.warn("Error: library index file '{s}' does not exist\n", .{indexFile});
         std.debug.warn("       Run the following to clone it:\n", .{});
-        std.debug.warn("       git clone {} {}\n", .{url, std.fs.path.dirname(indexFile)});
+        std.debug.warn("       git clone {s} {s}\n", .{url, std.fs.path.dirname(indexFile)});
         std.os.exit(1);
     };
 }

--- a/build.zig
+++ b/build.zig
@@ -4,9 +4,9 @@ const Pkg = std.build.Pkg;
 
 fn checkPackage(indexFile: []const u8, url: []const u8, ) void {
     std.fs.cwd().access(indexFile, std.fs.File.OpenFlags { .read = true }) catch |err| {
-        std.debug.warn("Error: library index file '{s}' does not exist\n", .{indexFile});
-        std.debug.warn("       Run the following to clone it:\n", .{});
-        std.debug.warn("       git clone {s} {s}\n", .{url, std.fs.path.dirname(indexFile)});
+        std.debug.print("Error: library index file '{s}' does not exist\n", .{indexFile});
+        std.debug.print("       Run the following to clone it:\n", .{});
+        std.debug.print("       git clone {s} {s}\n", .{url, std.fs.path.dirname(indexFile)});
         std.os.exit(1);
     };
 }

--- a/zigup.zig
+++ b/zigup.zig
@@ -340,7 +340,7 @@ const DownloadIndex = struct {
 fn fetchDownloadIndex(allocator: *Allocator) !DownloadIndex {
     const text = downloadToString(allocator, download_index_url) catch |e| switch (e) {
         else => {
-            std.debug.print("failed to download '{s}': {s}\n", .{ download_index_url, e });
+            std.debug.print("failed to download '{s}': {}\n", .{ download_index_url, e });
             return e;
         },
     };


### PR DESCRIPTION
- use {s} specifier to print strings, replace warn with print

Related: marler8997/ziget#3