### PR TITLE
add artifact ci

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -5,15 +5,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        #include:
-        #- os: macos-latest
-          #zigetsha: $(type zigetsha)
-
-        #- os: ubuntu-latest
-          #zigetsha: $(cat zigetsha)
-
-        #- os: ubuntu-latest
-          #zigetsha: $(cat zigetsha)
       fail-fast: false
     runs-on: ${{matrix.os}}
     steps:
@@ -21,13 +12,13 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: master
-        # should be type for windows
       - run: |
           git clone https://github.com/marler8997/ziget ./dep/ziget
           git -C ./dep/ziget checkout $(cat zigetsha) -b for_zigup
           git clone https://github.com/alexnask/iguanaTLS ./dep/iguanaTLS
           git -C ./dep/iguanaTLS checkout 0c0b357664397965936175d551576004cdf9da0d -b for_ziget
-          zig build -Diguana -Dcpu=baseline
+          zig build test -Diguana -Dcpu=baseline
+        shell: bash
       - uses: actions/upload-artifact@v2
         with:
           name: zigup ${{ matrix.os }}

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -1,0 +1,34 @@
+name: Artifacts
+on: [push]
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        #include:
+        #- os: macos-latest
+          #zigetsha: $(type zigetsha)
+
+        #- os: ubuntu-latest
+          #zigetsha: $(cat zigetsha)
+
+        #- os: ubuntu-latest
+          #zigetsha: $(cat zigetsha)
+      fail-fast: false
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: master
+        # should be type for windows
+      - run: |
+          git clone https://github.com/marler8997/ziget ./dep/ziget
+          git -C ./dep/ziget checkout $(cat zigetsha) -b for_zigup
+          git clone https://github.com/alexnask/iguanaTLS ./dep/iguanaTLS
+          git -C ./dep/iguanaTLS checkout 0c0b357664397965936175d551576004cdf9da0d -b for_ziget
+          zig build -Diguana -Dcpu=baseline
+      - uses: actions/upload-artifact@v2
+        with:
+          name: zigup ${{ matrix.os }}
+          path: zig-out/bin/*


### PR DESCRIPTION
Currently produces artifacts for linux and macos, windows is still borked. Should be easy enough to compile for other arches using zig and packaging them in the linux artifact