### PR TITLE
Implement ``zigup default master``

### DIFF
--- a/test.zig
+++ b/test.zig
@@ -34,7 +34,6 @@ pub fn main() !void {
         defer { allocator.free(result.stdout); allocator.free(result.stderr); }
         try testing.expect(std.mem.containsAtLeast(u8, result.stderr, 1, "Usage"));
     }
-
     {
         const result = try runCaptureOuts(allocator, ".", zigup_args ++ &[_][]const u8 {"default"});
         defer { allocator.free(result.stdout); allocator.free(result.stderr); }
@@ -80,6 +79,7 @@ pub fn main() !void {
         dumpExecResult(result);
         try testing.expect(std.mem.eql(u8, result.stdout, "0.6.0\n"));
     }
+    try runNoCapture(".", zigup_args ++ &[_][]const u8 {"default", "master"});
     {
         const result = try runCaptureOuts(allocator, ".", zigup_args ++ &[_][]const u8 {"list"});
         defer { allocator.free(result.stdout); allocator.free(result.stderr); }

--- a/test.zig
+++ b/test.zig
@@ -25,6 +25,11 @@ pub fn main() !void {
     const allocator = allocator_store.allocator();
 
     {
+        const result = try runCaptureOuts(allocator, ".", zigup_args ++ &[_][]const u8 {"default", "master"});
+        defer { allocator.free(result.stdout); allocator.free(result.stderr); }
+        try testing.expect(std.mem.containsAtLeast(u8, result.stderr, 1, "master has not been fetched"));
+    }
+    {
         const result = try runCaptureOuts(allocator, ".", zigup_args ++ &[_][]const u8 {"-h"});
         defer { allocator.free(result.stdout); allocator.free(result.stderr); }
         try testing.expect(std.mem.containsAtLeast(u8, result.stderr, 1, "Usage"));

--- a/zigup.zig
+++ b/zigup.zig
@@ -292,11 +292,7 @@ pub fn main2() !u8 {
             defer allocator.free(install_dir);
             const compiler_dir = try std.fs.path.join(allocator, &[_][]const u8{ install_dir, version_string });
             defer allocator.free(compiler_dir);
-            if (std.mem.eql(u8, version_string, "master")) {
-                @panic("set default to master not implemented");
-            } else {
-                try setDefaultCompiler(allocator, compiler_dir, .verify_existence);
-            }
+            try setDefaultCompiler(allocator, compiler_dir, .verify_existence);
             return 0;
         }
         std.debug.print("Error: 'default' command requires 1 or 2 arguments but got {d}\n", .{args.len - 1});


### PR DESCRIPTION
It just removes the explicit check as missing of ``master`` symlink would already get detected by setDefaultCompiler().
Implements as per discussed on discord/issue topic.

I noticed that you aren't doing zig fmt, so I didn't did it either.

Closes #33 