### PR TITLE
Return 0 code on help command and pass cli arguments to zig build run

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -1,5 +1,5 @@
 name: Artifacts
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     strategy:

--- a/build2.zig
+++ b/build2.zig
@@ -57,6 +57,9 @@ pub fn build(b: *Builder) !void {
 
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 
     addTest(b, exe, target, mode);
 }

--- a/zigup.zig
+++ b/zigup.zig
@@ -203,7 +203,7 @@ pub fn main2() !u8 {
                 }
             } else if (std.mem.eql(u8, "-h", arg) or std.mem.eql(u8, "--help", arg)) {
                 help();
-                return 1;
+                return 0;
             } else {
                 args[newlen] = args[i];
                 newlen += 1;


### PR DESCRIPTION
While working on #44 I noticed that

1) ``zig build run -- --help``  is returning 1 while it should return 0 as its a successful execution of a command. After changing it, I found that,
2) Build.zig is not passing CLI arguments to zig build run in the first place :sweat_smile: 