### PR TITLE
Implement command: zigup run

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ zigup clean [<version>]
 
 # mark a compiler to keep
 zigup keep <version>
+
+# run a specific version of the copmiler
+zigup run <version> <args>...
 ```
 
 # How the compilers are managed

--- a/test.zig
+++ b/test.zig
@@ -133,7 +133,11 @@ pub fn main() !u8 {
     }
     try runNoCapture(zigup_args ++ &[_][]const u8 {"default", "0.5.0"});
     try testing.expectEqual(@as(u32, 3), try getCompilerCount(install_dir));
-
+    {
+        const result = try runCaptureOuts(allocator, zigup_args ++ &[_][]const u8 {"run", "0.6.0", "version"});
+        defer { allocator.free(result.stdout); allocator.free(result.stderr); }
+        try testing.expect(std.mem.containsAtLeast(u8, result.stdout, 1, "0.6.0"));
+    }
     try runNoCapture(zigup_args ++ &[_][]const u8 {"keep", "0.6.0"});
     // doesn't delete anything because we have keepfile and master doens't get deleted
     try runNoCapture(zigup_args ++ &[_][]const u8 {"clean"});

--- a/test.zig
+++ b/test.zig
@@ -136,7 +136,12 @@ pub fn main() !u8 {
     {
         const result = try runCaptureOuts(allocator, zigup_args ++ &[_][]const u8 {"run", "0.6.0", "version"});
         defer { allocator.free(result.stdout); allocator.free(result.stderr); }
-        try testing.expect(std.mem.containsAtLeast(u8, result.stdout, 1, "0.6.0"));
+        try testing.expectEqualSlices(u8, "0.6.0\n", result.stdout);
+    }
+    {
+        const result = try runCaptureOuts(allocator, zigup_args ++ &[_][]const u8 {"run", "doesnotexist", "version"});
+        defer { allocator.free(result.stdout); allocator.free(result.stderr); }
+        try testing.expectEqualSlices(u8, "error: compiler 'doesnotexist' does not exist, fetch it first with: zigup fetch doesnotexist\n", result.stderr);
     }
     try runNoCapture(zigup_args ++ &[_][]const u8 {"keep", "0.6.0"});
     // doesn't delete anything because we have keepfile and master doens't get deleted


### PR DESCRIPTION
Implements the command with the signature ``zigup run <version> <args>...`` or ``zigup run <version> -- <args>``

This PR implements the concept of positional arguments into zigup. This is because commands like ``zigup run 0.8.1 --help`` for example, would run --help command of zigup as opposed to zig 0.8.1, so the solution was to use positional arguments to reliably pass arguments into the compiler

Doesn't work for ``zigup run master``

Closes #23 

Open question:
1) ~~Should master be allowed? If so then same way as ``zigup default``?~~
2) ~~Is this way to pass args ok? The other solution is to pass all the arguments as a single string, that should be simple to implement, as per desired.~~