### PR TITLE
Add support for nightly builds compiler versions

### DIFF
--- a/test.zig
+++ b/test.zig
@@ -205,6 +205,8 @@ pub fn main() !u8 {
             try testing.expect(std.mem.containsAtLeast(u8, result.stderr, 1, " is lower priority in PATH than "));
         }
     }
+    // verify at least one nightly build version
+    try runNoCapture(zigup_args ++ &[_][]const u8 {"0.10.0-dev.2306+50a5ddecc"});
 
     std.log.info("Success", .{});
     return 0;


### PR DESCRIPTION
I was trying to `zigup` install a compatible version of zig to use with [zls](https://github.com/zigtools/zls),  on `0.10-dev`, and couldn't get it to work. A specific nightly build was what I needed.

I was able to get it working by adding a fallback url (so if the download version fails, a nightly version is attempted next). Let me know if any changes or improvements... I am new to zig.

Also, thanks for making `zigup`! 
