### PR TITLE
riscv64 added

### DIFF
--- a/zigup.zig
+++ b/zigup.zig
@@ -15,6 +15,7 @@ const fixdeletetree = @import("fixdeletetree.zig");
 const arch = switch(builtin.cpu.arch) {
     .x86_64 => "x86_64",
     .aarch64 => "aarch64",
+    .riscv64 => "riscv64",
     else => @compileError("Unsupported CPU Architecture"),
 };
 const os = switch(builtin.os.tag) {


### PR DESCRIPTION
Test on Allwinner D1 Nezha (RV64GCV)

Target: `riscv64-linux-musl`
CPU: `baseline_rv64`(GC) or `baseline_rv64+v` (GCV)

**Note:** LLVM & Zig does not recognize Xuantie(T-Head) CPU only sifive.

### Show Builtin

<details>
<summary>File Contents</summary>

```zig
const std = @import("std");
/// Zig version. When writing code that supports multiple versions of Zig, prefer
/// feature detection (i.e. with `@hasDecl` or `@hasField`) over version checks.
pub const zig_version = std.SemanticVersion.parse("0.9.1") catch unreachable;
/// Temporary until self-hosted is feature complete.
pub const zig_is_stage2 = false;
/// Temporary until self-hosted supports the `cpu.arch` value.
pub const stage2_arch: std.Target.Cpu.Arch = .riscv64;
/// Temporary until self-hosted can call `std.Target.x86.featureSetHas` at comptime.
pub const stage2_x86_cx16 = false;

pub const output_mode = std.builtin.OutputMode.Exe;
pub const link_mode = std.builtin.LinkMode.Static;
pub const is_test = false;
pub const single_threaded = false;
pub const abi = std.Target.Abi.musl;
pub const cpu: std.Target.Cpu = .{
    .arch = .riscv64,
    .model = &std.Target.riscv.cpu.baseline_rv64,
    .features = std.Target.riscv.featureSet(&[_]std.Target.riscv.Feature{
        .@"64bit",
        .a,
        .c,
        .d,
        .f,
        .m,
        .experimental_v,
    }),
};
pub const os = std.Target.Os{
    .tag = .linux,
    .version_range = .{ .linux = .{
        .range = .{
            .min = .{
                .major = 5,
                .minor = 18,
                .patch = 0,
            },
            .max = .{
                .major = 5,
                .minor = 18,
                .patch = 0,
            },
        },
        .glibc = .{
            .major = 2,
            .minor = 19,
            .patch = 0,
        },
    }},
};
pub const target = std.Target{
    .cpu = cpu,
    .os = os,
    .abi = abi,
};
pub const object_format = std.Target.ObjectFormat.elf;
pub const mode = std.builtin.Mode.Debug;
pub const link_libc = false;
pub const link_libcpp = false;
pub const have_error_return_tracing = true;
pub const valgrind_support = false;
pub const position_independent_code = false;
pub const position_independent_executable = false;
pub const strip_debug_info = false;
pub const code_model = std.builtin.CodeModel.default;
```