### PR TITLE
Proper home support on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ zigup run <version> <args>...
 
 # How the compilers are managed
 
-zigup stores each compiler in a global "install directory" in a versioned subdirectory.  On posix systems the "install directory" is `$HOME/zig` and on windows the install directory will be a directory named "zig" in the same directory as the "zigup.exe".
+zigup stores each compiler in a global "install directory" in a versioned subdirectory.  On posix systems the "install directory" is `$HOME/.local/share/zig` and on windows the install directory will be a directory named "zig" in the same directory as the "zigup.exe".
 
 zigup makes the zig program available by creating an entry in a directory that occurs in the `PATH` environment variable.  On posix systems this entry is a symlink to one of the `zig` executables in the install directory.  On windows this is an executable that forwards invocations to one of the `zig` executables in the install directory.
 

--- a/zigup.zig
+++ b/zigup.zig
@@ -424,12 +424,17 @@ fn fetchDownloadIndex(allocator: Allocator) !DownloadIndex {
 }
 
 fn loggyMakeDirAbsolute(dir_absolute: []const u8) !void {
+    std.fs.makeDirAbsolute(dir_absolute) catch |e| {
+        if (e == error.PathAlreadyExists) {
+            return;
+        }
+        return e;
+    };
     if (builtin.os.tag == .windows) {
         loginfo("mkdir \"{s}\"", .{dir_absolute});
     } else {
         loginfo("mkdir '{s}'", .{dir_absolute});
     }
-    try std.fs.makeDirAbsolute(dir_absolute);
 }
 
 fn loggyDeleteTreeAbsolute(dir_absolute: []const u8) !void {

--- a/zigup.zig
+++ b/zigup.zig
@@ -92,7 +92,7 @@ fn allocInstallDirString(allocator: Allocator) ![]const u8 {
         std.log.err("$HOME environment variable '{s}' is not an absolute path", .{home});
         return error.BadHomeEnvironmentVariable;
     }
-    return std.fs.path.join(allocator, &[_][]const u8{ home, "zig" });
+    return std.fs.path.join(allocator, &[_][]const u8{ home, ".local", "share", "zig" });
 }
 const GetInstallDirOptions = struct {
     create: bool,


### PR DESCRIPTION
I'm not sure how other posix OS will handle this. On Linux `~/.local/share/zig` is the proper path to use.