### PR TITLE
Add CI build for aarch64 for all platforms

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -4,6 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
+        arch: [x86_64, aarch64]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{matrix.os}}
@@ -13,9 +14,12 @@ jobs:
         with:
           version: 0.10.0-dev.3027+0e26c6149
       - run: |
-          zig build test -Dfetch -Dci_target=${{matrix.os}}
+          zig build test -Dfetch -Dci_target=${{matrix.os}}-x86_64
+      - if: matrix.arch != 'x86_64'
+        run: |
+          zig build -Dfetch -Dci_target=${{matrix.os}}-${{matrix.arch}}
         shell: bash
       - uses: actions/upload-artifact@v2
         with:
-          name: zigup ${{ matrix.os }}
+          name: zigup ${{ matrix.os }}-${{ matrix.arch }}
           path: zig-out/bin/*

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -6,11 +6,6 @@ jobs:
       matrix:
         arch: [x86_64]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - arch: aarch64
-            os: ubuntu-latest
-          - arch: aarch64
-            os: macos-latest
       fail-fast: false
     runs-on: ${{matrix.os}}
     steps:
@@ -21,16 +16,21 @@ jobs:
       - run: |
           zig build test -Dfetch -Dci_target=${{matrix.os}}-${{matrix.arch}}
       - run: |
-          zig build -Dfetch -Dci_target=ubuntu-latest-x86_64 -p zig-out-ubuntu-x86_64
+          zig build -Dfetch -Dci_target=ubuntu-latest-x86_64 -p zig-out-ubuntu-latest-x86_64
       - run: |
-          zig build -Dfetch -Dci_target=ubuntu-latest-aarch64 -p zig-out-ubuntu-aarch64
+          zig build -Dfetch -Dci_target=ubuntu-latest-aarch64 -p zig-out-ubuntu-latest-aarch64
       - run: |
-          zig build -Dfetch -Dci_target=macos-latest-x86_64 -p zig-out-macos-x86_64
+          zig build -Dfetch -Dci_target=macos-latest-x86_64 -p zig-out-macos-latest-x86_64
       - run: |
-          zig build -Dfetch -Dci_target=macos-latest-aarch64 -p zig-out-macos-aarch64
+          zig build -Dfetch -Dci_target=macos-latest-aarch64 -p zig-out-macos-latest-aarch64
       - run: |
-          zig build -Dfetch -Dci_target=windows-latest-x86_64 -p zig-out-windows-x86_64
+          zig build -Dfetch -Dci_target=windows-latest-x86_64 -p zig-out-windows-latest-x86_64
       - uses: actions/upload-artifact@v2
         with:
           name: zigup ${{ matrix.os }}-${{ matrix.arch }}
           path: zig-out/bin/*
+      - if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: zigup ${{ matrix.os }}-aarch64
+          path: zig-out-${{matrix.os}}-aarch64/bin/*

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -4,8 +4,13 @@ jobs:
   test:
     strategy:
       matrix:
-        arch: [x86_64, aarch64]
+        arch: [x86_64]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - arch: aarch64
+            os: ubuntu-latest
+          - arch: aarch64
+            os: macos-latest
       fail-fast: false
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -19,11 +19,17 @@ jobs:
         with:
           version: 0.10.0-dev.3027+0e26c6149
       - run: |
-          zig build test -Dfetch -Dci_target=${{matrix.os}}-x86_64
-      - if: matrix.arch != 'x86_64'
-        run: |
-          zig build -Dfetch -Dci_target=${{matrix.os}}-${{matrix.arch}}
-        shell: bash
+          zig build test -Dfetch -Dci_target=${{matrix.os}}-${{matrix.arch}}
+      - run: |
+          zig build -Dfetch -Dci_target=ubuntu-latest-x86_64 -p zig-out-ubuntu-x86_64
+      - run: |
+          zig build -Dfetch -Dci_target=ubuntu-latest-aarch64 -p zig-out-ubuntu-aarch64
+      - run: |
+          zig build -Dfetch -Dci_target=macos-latest-x86_64 -p zig-out-macos-x86_64
+      - run: |
+          zig build -Dfetch -Dci_target=macos-latest-aarch64 -p zig-out-macos-aarch64
+      - run: |
+          zig build -Dfetch -Dci_target=windows-latest-x86_64 -p zig-out-windows-x86_64
       - uses: actions/upload-artifact@v2
         with:
           name: zigup ${{ matrix.os }}-${{ matrix.arch }}

--- a/build2.zig
+++ b/build2.zig
@@ -199,5 +199,4 @@ const ci_target_map = std.ComptimeStringMap([]const u8, .{
     .{ "windows-latest-x86_64", "x86_64-windows" },
     .{ "ubuntu-latest-aarch64", "aarch64-linux" },
     .{ "macos-latest-aarch64", "aarch64-macos" },
-    .{ "windows-latest-aarch64", "aarch64-windows" },
 });

--- a/build2.zig
+++ b/build2.zig
@@ -194,7 +194,10 @@ fn join(b: *Builder, parts: []const []const u8) ![]const u8 {
 }
 
 const ci_target_map = std.ComptimeStringMap([]const u8, .{
-    .{ "ubuntu-latest", "x86_64-linux" },
-    .{ "macos-latest", "x86_64-macos" },
-    .{ "windows-latest", "x86_64-windows" },
+    .{ "ubuntu-latest-x86_64", "x86_64-linux" },
+    .{ "macos-latest-x86_64", "x86_64-macos" },
+    .{ "windows-latest-x86_64", "x86_64-windows" },
+    .{ "ubuntu-latest-aarch64", "aarch64-linux" },
+    .{ "macos-latest-aarch64", "aarch64-macos" },
+    .{ "windows-latest-aarch64", "aarch64-windows" },
 });


### PR DESCRIPTION
closes #60 

This change introduces the ability to build aarch64 binaries and upload the artifacts. 
The CI can also be expanded to include other architectures. Sample run: [here](https://github.com/xEgoist/zigup/actions/runs/2914581904)

Because it's hard to test these builds on Github Action (with the exception of running linux builds under qemu), tests were left to the x86_64 builds.   