### PR TITLE
replace zarc dependency with zig-archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ cp zig-out/bin/zigup BIN_PATH
 
 zigup depends on https://github.com/marler8997/ziget which in turn depends on other projects depending on which SSL backend is selected.  You can provide `-Dfetch` to `zig build` to automatically clone all repository dependencies, otherwise, the build will report a missing dependency error with an explanation of how to clone it.
 
-The windows target depends on https://github.com/SuperAuguste/zarc to extract zip files.  This repo might point to my fork if there are needed changes pending the acceptance of a PR: https://github.com/marler8997/zarc.
+The windows target depends on https://github.com/truemedian/zig-archive to extract zip files.
 
 On linux and macos, zigup depends on `tar` to extract the compiler archive files (this may change in the future).

--- a/build2.zig
+++ b/build2.zig
@@ -140,16 +140,16 @@ fn addZigupExe(
     zigetbuild.addZigetPkg(exe, ssl_backend, ziget_repo.getPath(&exe.step));
 
     if (targetIsWindows(target)) {
-        const zarc_repo = GitRepoStep.create(b, .{
-            .url = "https://github.com/marler8997/zarc",
-            .branch = "protected",
-            .sha = "ca9554ffbfceedec6aae5f39fc71a52dbdec2a15",
+        const zig_archive_repo = GitRepoStep.create(b, .{
+            .url = "https://github.com/truemedian/zig-archive",
+            .branch = null,
+            .sha = "eae4544dd3d3b7ce05ab45a953f5a8302440c570",
         });
-        exe.step.dependOn(&zarc_repo.step);
-        const zarc_repo_path = zarc_repo.getPath(&exe.step);
+        exe.step.dependOn(&zig_archive_repo.step);
+        const zig_archive_repo_path = zig_archive_repo.getPath(&exe.step);
         exe.addPackage(Pkg {
-            .name = "zarc",
-            .source = .{ .path = try join(b, &[_][]const u8 { zarc_repo_path, "src", "main.zig" }) },
+            .name = "zig-archive",
+            .source = .{ .path = try join(b, &[_][]const u8 { zig_archive_repo_path, "src", "main.zig" }) },
         });
     }
 

--- a/zigup.zig
+++ b/zigup.zig
@@ -8,7 +8,7 @@ const ArrayList = std.ArrayList;
 const Allocator = mem.Allocator;
 
 const ziget = @import("ziget");
-const zarc = @import("zarc");
+const zig_archive = @import("zig-archive");
 
 const fixdeletetree = @import("fixdeletetree.zig");
 
@@ -934,10 +934,11 @@ fn installCompiler(allocator: Allocator, compiler_dir: []const u8, url: []const 
                     var timer = try std.time.Timer.start();
                     var archive_file = try std.fs.openFileAbsolute(archive_absolute, .{});
                     defer archive_file.close();
-                    const reader = archive_file.reader();
-                    var archive = try zarc.zip.load(allocator, reader);
-                    defer archive.deinit(allocator);
-                    _ = try archive.extract(reader, installing_dir_opened, .{});
+                    var stream = std.io.StreamSource{ .file = archive_file };
+                    var archive_reader = zig_archive.formats.zip.reader.ArchiveReader.init(allocator, &stream);
+                    defer archive_reader.deinit();
+                    try archive_reader.load();
+                    //_ = try archive_reader.extract(reader, installing_dir_opened, .{});
                     const time = timer.read();
                     loginfo("extracted archive in {d:.2} s", .{@intToFloat(f32, time) / @intToFloat(f32, std.time.ns_per_s)});
                 }


### PR DESCRIPTION
Author of zarc no longer wants to maintain it and suggested I use truemedian's zig-archive instead.  Change is currently held up because zig-archive doesn't work on zig version "0.11.0-dev.1507+6f13a725a" yet.