### PR TITLE
remove zarc dependency in favor of powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,4 @@ cp zig-out/bin/zigup BIN_PATH
 
 zigup depends on https://github.com/marler8997/ziget which in turn depends on other projects depending on which SSL backend is selected.  You can provide `-Dfetch` to `zig build` to automatically clone all repository dependencies, otherwise, the build will report a missing dependency error with an explanation of how to clone it.
 
-The windows target depends on https://github.com/SuperAuguste/zarc to extract zip files.  This repo might point to my fork if there are needed changes pending the acceptance of a PR: https://github.com/marler8997/zarc.
-
 On linux and macos, zigup depends on `tar` to extract the compiler archive files (this may change in the future).

--- a/build2.zig
+++ b/build2.zig
@@ -154,20 +154,6 @@ fn addZigupExe(
     exe.step.dependOn(&ziget_repo.step);
     zigetbuild.addZigetModule(exe, ssl_backend, ziget_repo.getPath(&exe.step));
 
-    if (targetIsWindows(target)) {
-        const zarc_repo = GitRepoStep.create(b, .{
-            .url = "https://github.com/marler8997/zarc",
-            .branch = "protected",
-            .sha = "2e5256624d7871180badc9784b96dd66d927d604",
-        });
-        exe.step.dependOn(&zarc_repo.step);
-        const zarc_repo_path = zarc_repo.getPath(&exe.step);
-        const zarc_mod = b.addModule("zarc", .{
-            .source_file = .{ .path = b.pathJoin(&.{ zarc_repo_path, "src", "main.zig" }) },
-        });
-        exe.addModule("zarc", zarc_mod);
-    }
-
     exe.step.dependOn(&require_ssl_backend.step);
     return exe;
 }


### PR DESCRIPTION
We can remove the zarc dependency (I no longer need to maintain it) by leveraging powershell, however, this appears to be ungodly slow.  7 times slower on the CI (test took 14 minutes instead of 2).  It looks like this is a longtime known issue: https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/32

Another option would be to use `System.IO.Compression.ZipFile` from the .NET runtime with a fallback to powershell, this is what goto-bus-stop/setup-zig does, i.e.

```batch
> "C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\0cb5b10f-ac04-4c24-b695-a765775d31fa', 'D:\a\_temp\245aed94-f57d-47db-8abe-29f7e193e5d6', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\0cb5b10f-ac04-4c24-b695-a765775d31fa' -DestinationPath 'D:\a\_temp\245aed94-f57d-47db-8abe-29f7e193e5d6' -Force } else { throw $_ } } ;"
```

see `extractZip` function in https://raw.githubusercontent.com/goto-bus-stop/setup-zig/default/dist/index.js