### PR TITLE
Windows: Use %LOCALAPPDATA%/zigup as the default install directory.

### DIFF
--- a/test.zig
+++ b/test.zig
@@ -23,7 +23,7 @@ pub fn main() !u8 {
     try std.fs.cwd().makeDir("scratch");
     const bin_dir = "scratch" ++ sep ++ "bin";
     try std.fs.cwd().makeDir(bin_dir);
-    const install_dir = if (builtin.os.tag == .windows) (bin_dir ++ "\\zig") else ("scratch/install");
+    const install_dir = "scratch/install";
     try std.fs.cwd().makeDir(install_dir);
 
     // NOTE: for now we are incorrectly assuming the install dir is CWD/zig-out
@@ -35,7 +35,7 @@ pub fn main() !u8 {
         .{},
     );
 
-    const install_args = if (builtin.os.tag == .windows) [_][]const u8{} else [_][]const u8{ "--install-dir", install_dir };
+    const install_args = [_][]const u8{ "--install-dir", install_dir };
     const zigup_args = &[_][]const u8{zigup} ++ install_args;
 
     var allocator_store = std.heap.ArenaAllocator.init(std.heap.page_allocator);


### PR DESCRIPTION
The previous behaviour was to use the zigup executable's own directory.

The previous behaviour would result in both a `zig` directory, and a `zig.exe` file in the user's PATH. The directory would prevent the linked zig executable created by zigup from being found in PATH when running under MSYS (e.g. trying to use zigup from within the bash install that comes with git for windows). Using %LOCALAPPDATA% avoids this issue and better matches the behaviour on other platforms.

Tested on Windows and Linux (under WSL) with LOCALAPPDATA/HOME:

* Unset.
* Set to a bad path.
* Set normally.

Observed expected error output/success.