### PR TITLE
Use the known-folders package to find install dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ zigup run <version> <args>...
 
 # How the compilers are managed
 
-zigup stores each compiler in a global "install directory" in a versioned subdirectory.  On posix systems the "install directory" is `$HOME/zig` and on windows the install directory will be a directory named "zig" in the same directory as the "zigup.exe".
+zigup stores each compiler in a global "install directory" in a versioned subdirectory.  The "install directory" is a subdirectory called `zigup` of a platform-specific directory. The platform-specific parent directories are:
+
+  - `XDG_DATA_HOME` on Linux—*i.e.* `$XDG_DATA_HOME` with a default of `~/.local/share`,
+  - `~/Library/Application Support/zigup` on macOS,
+  - `%APPDATA/zigup` on Windows.
+
+Using the build option `-Ddefault-dir=[DIR]` changes the install directory so that on posix systems the install directory is `$HOME/[DIR]` and on windows the install directory will be a directory named `[DIR]` in the same directory as the "zigup.exe".
 
 zigup makes the zig program available by creating an entry in a directory that occurs in the `PATH` environment variable.  On posix systems this entry is a symlink to one of the `zig` executables in the install directory.  On windows this is an executable that forwards invocations to one of the `zig` executables in the install directory.
 

--- a/build.zig
+++ b/build.zig
@@ -134,7 +134,7 @@ fn ci(
     var previous_test_step = test_step;
 
     for (ci_targets) |ci_target_str| {
-        const target = b.resolveTargetQuery(try std.zig.CrossTarget.parse(
+        const target = b.resolveTargetQuery(try std.Target.Query.parse(
             .{ .arch_os_abi = ci_target_str },
         ));
         const optimize: std.builtin.OptimizeMode =

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,13 @@
 .{
     .name = "zigup",
     .version = "0.0.1",
+    .dependencies = .{
+        .known_folders = .{
+            .url = "https://github.com/ziglibs/known-folders/archive/47076c6b11214a218e9244471d8762310820911a.tar.gz",
+            .hash = "12209d2738a2e1dbd3781c2e5f01a2ea877dcfeea53efdfa1913247297d328e6b207",
+            .lazy = true,
+        },
+    },
 
     .paths = .{
         "LICENSE",

--- a/zigup.zig
+++ b/zigup.zig
@@ -501,7 +501,7 @@ pub fn loggySymlinkAbsolute(target_path: []const u8, sym_link_path: []const u8, 
 
 /// returns: true if the symlink was updated, false if it was already set to the given `target_path`
 pub fn loggyUpdateSymlink(target_path: []const u8, sym_link_path: []const u8, flags: std.fs.Dir.SymLinkFlags) !bool {
-    var current_target_path_buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var current_target_path_buffer: [std.fs.max_path_bytes]u8 = undefined;
     if (std.fs.readLinkAbsolute(sym_link_path, &current_target_path_buffer)) |current_target_path| {
         if (std.mem.eql(u8, target_path, current_target_path)) {
             loginfo("symlink '{s}' already points to '{s}'", .{ sym_link_path, target_path });
@@ -631,7 +631,7 @@ fn cleanCompilers(allocator: Allocator, compiler_name_opt: ?[]const u8) !void {
         }
     }
 }
-fn readDefaultCompiler(allocator: Allocator, buffer: *[std.fs.MAX_PATH_BYTES + 1]u8) !?[]const u8 {
+fn readDefaultCompiler(allocator: Allocator, buffer: *[std.fs.max_path_bytes + 1]u8) !?[]const u8 {
     const path_link = try makeZigPathLinkString(allocator);
     defer allocator.free(path_link);
 
@@ -651,7 +651,7 @@ fn readDefaultCompiler(allocator: Allocator, buffer: *[std.fs.MAX_PATH_BYTES + 1
         return try allocator.dupe(u8, targetPathToVersion(target_exe));
     }
 
-    const target_path = std.fs.readLinkAbsolute(path_link, buffer[0..std.fs.MAX_PATH_BYTES]) catch |e| switch (e) {
+    const target_path = std.fs.readLinkAbsolute(path_link, buffer[0..std.fs.max_path_bytes]) catch |e| switch (e) {
         error.FileNotFound => return null,
         else => return e,
     };
@@ -662,7 +662,7 @@ fn targetPathToVersion(target_path: []const u8) []const u8 {
     return std.fs.path.basename(std.fs.path.dirname(std.fs.path.dirname(target_path).?).?);
 }
 
-fn readMasterDir(buffer: *[std.fs.MAX_PATH_BYTES]u8, install_dir: *std.fs.Dir) !?[]const u8 {
+fn readMasterDir(buffer: *[std.fs.max_path_bytes]u8, install_dir: *std.fs.Dir) !?[]const u8 {
     if (builtin.os.tag == .windows) {
         var file = install_dir.openFile("master", .{}) catch |e| switch (e) {
             error.FileNotFound => return null,
@@ -678,7 +678,7 @@ fn readMasterDir(buffer: *[std.fs.MAX_PATH_BYTES]u8, install_dir: *std.fs.Dir) !
 }
 
 fn getDefaultCompiler(allocator: Allocator) !?[]const u8 {
-    var buffer: [std.fs.MAX_PATH_BYTES + 1]u8 = undefined;
+    var buffer: [std.fs.max_path_bytes + 1]u8 = undefined;
     const slice_path = (try readDefaultCompiler(allocator, &buffer)) orelse return null;
     const path_to_return = try allocator.alloc(u8, slice_path.len);
     @memcpy(path_to_return, slice_path);
@@ -686,7 +686,7 @@ fn getDefaultCompiler(allocator: Allocator) !?[]const u8 {
 }
 
 fn getMasterDir(allocator: Allocator, install_dir: *std.fs.Dir) !?[]const u8 {
-    var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buffer: [std.fs.max_path_bytes]u8 = undefined;
     const slice_path = (try readMasterDir(&buffer, install_dir)) orelse return null;
     const path_to_return = try allocator.alloc(u8, slice_path.len);
     @memcpy(path_to_return, slice_path);
@@ -773,7 +773,7 @@ fn verifyPathLink(allocator: Allocator, path_link: []const u8) !void {
             break :blk "";
         };
 
-        var path_it = std.mem.tokenize(u8, path_env, ";");
+        var path_it = std.mem.tokenizeScalar(u8, path_env, ';');
         while (path_it.next()) |path| {
             switch (try compareDir(path_link_dir_id, path)) {
                 .missing => continue,
@@ -789,7 +789,7 @@ fn verifyPathLink(allocator: Allocator, path_link: []const u8) !void {
                 try enforceNoZig(path_link, exe);
             }
 
-            var ext_it = std.mem.tokenize(u8, pathext_env, ";");
+            var ext_it = std.mem.tokenizeScalar(u8, pathext_env, ';');
             while (ext_it.next()) |ext| {
                 if (ext.len == 0) continue;
                 const basename = try std.mem.concat(allocator, u8, &.{ "zig", ext });
@@ -802,7 +802,7 @@ fn verifyPathLink(allocator: Allocator, path_link: []const u8) !void {
             }
         }
     } else {
-        var path_it = std.mem.tokenize(u8, std.posix.getenv("PATH") orelse "", ":");
+        var path_it = std.mem.tokenizeScalar(u8, std.posix.getenv("PATH") orelse "", ':');
         while (path_it.next()) |path| {
             switch (try compareDir(path_link_dir_id, path)) {
                 .missing => continue,
@@ -924,8 +924,8 @@ const win32exelink = struct {
     };
 };
 fn createExeLink(link_target: []const u8, path_link: []const u8) !void {
-    if (path_link.len > std.fs.MAX_PATH_BYTES) {
-        std.debug.print("Error: path_link (size {}) is too large (max {})\n", .{ path_link.len, std.fs.MAX_PATH_BYTES });
+    if (path_link.len > std.fs.max_path_bytes) {
+        std.debug.print("Error: path_link (size {}) is too large (max {})\n", .{ path_link.len, std.fs.max_path_bytes });
         return error.AlreadyReported;
     }
     const file = std.fs.cwd().createFile(path_link, .{}) catch |err| switch (err) {


### PR DESCRIPTION
This change makes zigup use [known-folders](https://github.com/ziglibs/known-folders) for determining the install directory by default. A new build option `default-dir` has been added to control whether the default behaviour is to use the `known-options` package or the old behaviour. When `default-dir` is provided everything is the same as before, except that instead of the use of `"zig"` as the name of the install directory, the value of the `default-dir` build option is used (i.e. for the old behaviour use `zig build -Ddefault-dir=zig`).

When the `default-dir` build option is not provided the changes to behaviour are that when the `--install-dir` option is _not_ provided:

  - a platform-specific standard directory is chosen, this will be the parent of the install directory for managing compilers
    + linux uses `XDG_DATA_HOME`, which defaults to `~/.local/share` if the `$XDG_DATA_HOME` env var is not set
    + mac uses `~/Library/Application Support`
    + windows uses the `%APPDATA%` env var
  - if the above platform-specific directory does not exist, zigup will report an error, rather than creating the directory
  - the zigup install (sub)directory underneath the above platform-specific directory is `zigup`, e.g. the default location on linux becomes `~/.local/share/zigup`.

Note that I am not very familiar with Windows and macOS conventions here, but I assume `known-folders` is making a sensible choice; it is possible to have `known-folders` use the XDG spec on macOS rather than using `~/Library/Application Support`.

In addition, the first commit in the PR updates use of some deprecated aliases in `std` that were made compile errors in the 0.13 release cycle. They were deprecated before Zig 0.12, so 0.12 still works, but with these Zig master can also build zigup. I can split this commit into a separate PR if that is preferable.

Compared to #66 (I had not noticed the apparent inactivity in that PR when I commented) I believe using `known-folders` is the right approach, and provides a build option as was suggested in comments on that PR to allow using original default behaviour.