### PR TITLE
add default-dir build option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,8 +5,17 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const default_dir = b.option(
+        []const u8,
+        "default-dir",
+        "Default compiler installation directory (default: zig)",
+    ) orelse "zig";
+
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "default_dir", default_dir);
+
     const zigup_exe_native = blk: {
-        const exe = addZigupExe(b, target, optimize);
+        const exe = addZigupExe(b, target, optimize, build_options);
         b.installArtifact(exe);
         const run_cmd = b.addRunArtifact(exe);
         run_cmd.step.dependOn(b.getInstallStep());
@@ -74,13 +83,14 @@ pub fn build(b: *std.Build) !void {
     ci_step.dependOn(test_step);
     ci_step.dependOn(unzip_step);
     ci_step.dependOn(zip_step);
-    try ci(b, ci_step, test_step, host_zip_exe);
+    try ci(b, ci_step, test_step, host_zip_exe, build_options);
 }
 
 fn addZigupExe(
     b: *std.Build,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.Mode,
+    build_options: *std.Build.Step.Options,
 ) *std.Build.Step.Compile {
     const win32exelink_mod: ?*std.Build.Module = blk: {
         if (target.result.os.tag == .windows) {
@@ -104,6 +114,8 @@ fn addZigupExe(
         .optimize = optimize,
     });
 
+    exe.root_module.addOptions("build-options", build_options);
+
     if (target.result.os.tag == .windows) {
         exe.root_module.addImport("win32exelink", win32exelink_mod.?);
     }
@@ -115,6 +127,7 @@ fn ci(
     ci_step: *std.Build.Step,
     test_step: *std.Build.Step,
     host_zip_exe: *std.Build.Step.Compile,
+    build_options: *std.Build.Step.Options,
 ) !void {
     const ci_targets = [_][]const u8{
         "x86_64-linux",
@@ -141,7 +154,7 @@ fn ci(
         const optimize: std.builtin.OptimizeMode =
             // Compile in ReleaseSafe on Windows for faster extraction
             if (target.result.os.tag == .windows) .ReleaseSafe else .Debug;
-        const zigup_exe = addZigupExe(b, target, optimize);
+        const zigup_exe = addZigupExe(b, target, optimize, build_options);
         const zigup_exe_install = b.addInstallArtifact(zigup_exe, .{
             .dest_dir = .{ .override = .{ .custom = ci_target_str } },
         });

--- a/zigup.zig
+++ b/zigup.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const mem = std.mem;
 
+const build_options = @import("build-options");
+
 const ArrayList = std.ArrayList;
 const Allocator = mem.Allocator;
 
@@ -131,14 +133,14 @@ fn allocInstallDirString(allocator: Allocator) ![]const u8 {
     if (builtin.os.tag == .windows) {
         const self_exe_dir = try std.fs.selfExeDirPathAlloc(allocator);
         defer allocator.free(self_exe_dir);
-        return std.fs.path.join(allocator, &.{ self_exe_dir, "zig" });
+        return std.fs.path.join(allocator, &.{ self_exe_dir, build_options.default_dir });
     }
     const home = try getHomeDir();
     if (!std.fs.path.isAbsolute(home)) {
         std.log.err("$HOME environment variable '{s}' is not an absolute path", .{home});
         return error.BadHomeEnvironmentVariable;
     }
-    return std.fs.path.join(allocator, &[_][]const u8{ home, "zig" });
+    return std.fs.path.join(allocator, &[_][]const u8{ home, build_options.default_dir });
 }
 const GetInstallDirOptions = struct {
     create: bool,


### PR DESCRIPTION
Extracted from #139.

This PR add a new build option `-Ddefault-dir` that sets the default installation directory.  It defaults to "zig" which means that this PR does not change any behaviour if the option is not provided to `zig build`.