### PR TITLE
Add support for installing compilers to XDG_DATA_HOME

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,8 +5,17 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const use_xdg = b.option(
+        bool,
+        "use-xdg",
+        "Use the XDG base directory specification (default: false)",
+    ) orelse false;
+
+    const build_options = b.addOptions();
+    build_options.addOption(bool, "use_xdg", use_xdg);
+
     const zigup_exe_native = blk: {
-        const exe = addZigupExe(b, target, optimize);
+        const exe = addZigupExe(b, target, optimize, build_options);
         b.installArtifact(exe);
         const run_cmd = b.addRunArtifact(exe);
         run_cmd.step.dependOn(b.getInstallStep());
@@ -74,13 +83,14 @@ pub fn build(b: *std.Build) !void {
     ci_step.dependOn(test_step);
     ci_step.dependOn(unzip_step);
     ci_step.dependOn(zip_step);
-    try ci(b, ci_step, test_step, host_zip_exe);
+    try ci(b, ci_step, test_step, host_zip_exe, build_options);
 }
 
 fn addZigupExe(
     b: *std.Build,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.Mode,
+    build_options: *std.Build.Step.Options,
 ) *std.Build.Step.Compile {
     const win32exelink_mod: ?*std.Build.Module = blk: {
         if (target.result.os.tag == .windows) {
@@ -104,6 +114,8 @@ fn addZigupExe(
         .optimize = optimize,
     });
 
+    exe.root_module.addOptions("build-options", build_options);
+
     if (target.result.os.tag == .windows) {
         exe.root_module.addImport("win32exelink", win32exelink_mod.?);
     }
@@ -115,6 +127,7 @@ fn ci(
     ci_step: *std.Build.Step,
     test_step: *std.Build.Step,
     host_zip_exe: *std.Build.Step.Compile,
+    build_options: *std.Build.Step.Options,
 ) !void {
     const ci_targets = [_][]const u8{
         "x86_64-linux",
@@ -141,7 +154,7 @@ fn ci(
         const optimize: std.builtin.OptimizeMode =
             // Compile in ReleaseSafe on Windows for faster extraction
             if (target.result.os.tag == .windows) .ReleaseSafe else .Debug;
-        const zigup_exe = addZigupExe(b, target, optimize);
+        const zigup_exe = addZigupExe(b, target, optimize, build_options);
         const zigup_exe_install = b.addInstallArtifact(zigup_exe, .{
             .dest_dir = .{ .override = .{ .custom = ci_target_str } },
         });


### PR DESCRIPTION
This PR add a build option `-Duse-xdg` that enables use of XDG_DATA_HOME for the installation directory on non-windows operating systems.

This PR conflicts with #141 - whichever gets merged first will cause minor fixups to be needed in the other.

Before merging:
- [ ] add tests to CI for binaries built with -Duse-xdg
