### PR TITLE
update win32exelink for deprecated std alias

### DIFF
--- a/win32exelink.zig
+++ b/win32exelink.zig
@@ -9,8 +9,8 @@ const exe_marker_len = 42;
 
 // I'm exporting this and making it mutable to make sure the compiler keeps it around
 // and prevent it from evaluting its contents at comptime
-export var zig_exe_string: [exe_marker_len + std.fs.MAX_PATH_BYTES + 1]u8 =
-    ("!!!THIS MARKS THE zig_exe_string MEMORY!!#" ++ ([1]u8{0} ** (std.fs.MAX_PATH_BYTES + 1))).*;
+export var zig_exe_string: [exe_marker_len + std.fs.max_path_bytes + 1]u8 =
+    ("!!!THIS MARKS THE zig_exe_string MEMORY!!#" ++ ([1]u8{0} ** (std.fs.max_path_bytes + 1))).*;
 
 const global = struct {
     var child: std.process.Child = undefined;
@@ -28,8 +28,8 @@ pub fn main() !u8 {
     var zig_exe_len: usize = 1;
     while (zig_exe_string[exe_marker_len + zig_exe_len] != 0) {
         zig_exe_len += 1;
-        if (exe_marker_len + zig_exe_len > std.fs.MAX_PATH_BYTES) {
-            log.err("the zig target execuable is either too big (over {}) or the exe is corrupt", .{std.fs.MAX_PATH_BYTES});
+        if (exe_marker_len + zig_exe_len > std.fs.max_path_bytes) {
+            log.err("the zig target execuable is either too big (over {}) or the exe is corrupt", .{std.fs.max_path_bytes});
             return 1;
         }
     }


### PR DESCRIPTION
This file was missed in the previous update (e37d205).