### PR TITLE
Show symlinks to compilers in `zigup list`

### DIFF
--- a/test.zig
+++ b/test.zig
@@ -49,13 +49,13 @@ pub fn main() !u8 {
     const bin_dir = try std.fs.path.join(allocator, &.{ test_dir, "bin" });
     try std.fs.cwd().makeDir(bin_dir);
     const install_sub_path = if (builtin.os.tag == .windows) "bin\\zig" else "install";
-    const install_dir = try std.fs.path.join(allocator, &.{test_dir, install_sub_path });
+    const install_dir = try std.fs.path.join(allocator, &.{ test_dir, install_sub_path });
     try std.fs.cwd().makeDir(install_dir);
 
     const zigup = try std.fs.path.join(allocator, &.{
         test_dir,
         "bin",
-        "zigup" ++ comptime builtin.target.exeFileExt()
+        "zigup" ++ comptime builtin.target.exeFileExt(),
     });
     try std.fs.cwd().copyFile(
         zigup_src_exe,
@@ -65,7 +65,9 @@ pub fn main() !u8 {
     );
     if (builtin.os.tag == .windows) {
         const zigup_src_pdb = try std.mem.concat(
-            allocator, u8, &.{ zigup_src_exe[0 .. zigup_src_exe.len-4], ".pdb" }
+            allocator,
+            u8,
+            &.{ zigup_src_exe[0 .. zigup_src_exe.len - 4], ".pdb" },
         );
         defer allocator.free(zigup_src_pdb);
         const zigup_pdb = try std.fs.path.join(allocator, &.{ test_dir, "bin\\zigup.pdb" });
@@ -73,10 +75,10 @@ pub fn main() !u8 {
         try std.fs.cwd().copyFile(zigup_src_pdb, std.fs.cwd(), zigup_pdb, .{});
     }
 
-    const install_args = if (builtin.os.tag == .windows) [_][]const u8{
-    } else [_][]const u8{
-        "--install-dir", install_dir,
-    };
+    const install_args = if (builtin.os.tag == .windows)
+        [_][]const u8{}
+    else
+        [_][]const u8{ "--install-dir", install_dir };
     const zigup_args = &[_][]const u8{zigup} ++ install_args;
 
     const path_link = try std.fs.path.join(allocator, &.{ bin_dir, comptime "zig" ++ builtin.target.exeFileExt() });
@@ -314,7 +316,7 @@ pub fn main() !u8 {
         {
             const fake_zig = try std.fs.path.join(allocator, &.{
                 bin2_dir,
-                "zig" ++ comptime builtin.target.exeFileExt()
+                "zig" ++ comptime builtin.target.exeFileExt(),
             });
             defer allocator.free(fake_zig);
             var file = try std.fs.cwd().createFile(fake_zig, .{});
@@ -348,7 +350,7 @@ pub fn main() !u8 {
     // NOTE: this test will eventually break when these builds are cleaned up,
     //       we should support downloading from bazel and use that instead since
     //       it should be more permanent
-    try runNoCapture(zigup_args ++ &[_][]const u8{ "0.14.0-dev.14+ec337051a" });
+    try runNoCapture(zigup_args ++ &[_][]const u8{"0.14.0-dev.14+ec337051a"});
 
     std.log.info("Success", .{});
     return 0;

--- a/unzip.zig
+++ b/unzip.zig
@@ -15,7 +15,10 @@ fn usage() noreturn {
 }
 
 var windows_args_arena = if (builtin.os.tag == .windows)
-    std.heap.ArenaAllocator.init(std.heap.page_allocator) else struct{}{};
+    std.heap.ArenaAllocator.init(std.heap.page_allocator)
+else
+    struct {}{};
+
 pub fn cmdlineArgs() [][*:0]u8 {
     if (builtin.os.tag == .windows) {
         const slices = std.process.argsAlloc(windows_args_arena.allocator()) catch |err| switch (err) {
@@ -29,7 +32,7 @@ pub fn cmdlineArgs() [][*:0]u8 {
         }
         return args;
     }
-    return std.os.argv.ptr[1 .. std.os.argv.len];
+    return std.os.argv.ptr[1..std.os.argv.len];
 }
 
 pub fn main() !void {
@@ -55,7 +58,7 @@ pub fn main() !void {
                 fatal("unknown cmdline option '{s}'", .{arg});
             }
         }
-        break :blk cmd_args[0 .. non_option_len];
+        break :blk cmd_args[0..non_option_len];
     };
 
     if (cmd_args.len != 1) usage();
@@ -68,7 +71,7 @@ pub fn main() !void {
                     try std.fs.cwd().makePath(dir);
                     break :blk try std.fs.cwd().openDir(dir, .{});
                 },
-                else => fatal("failed to open output directory '{s}' with {s}", .{dir, @errorName(err)}),
+                else => fatal("failed to open output directory '{s}' with {s}", .{ dir, @errorName(err) }),
             };
         }
         break :blk std.fs.cwd();
@@ -76,7 +79,7 @@ pub fn main() !void {
     defer if (cmdline_opt.dir_arg) |_| out_dir.close();
 
     const zip_file = std.fs.cwd().openFile(zip_file_arg, .{}) catch |err|
-        fatal("open '{s}' failed: {s}", .{zip_file_arg, @errorName(err)});
+        fatal("open '{s}' failed: {s}", .{ zip_file_arg, @errorName(err) });
     defer zip_file.close();
     try std.zip.extract(out_dir, zip_file.seekableStream(), .{
         .allow_backslashes = true,

--- a/zigup.zig
+++ b/zigup.zig
@@ -52,14 +52,17 @@ const DownloadResult = union(enum) {
 };
 fn download(allocator: Allocator, url: []const u8, writer: anytype) DownloadResult {
     const uri = std.Uri.parse(url) catch |err| std.debug.panic(
-        "failed to parse url '{s}' with {s}", .{url, @errorName(err)}
+        "failed to parse url '{s}' with {s}",
+        .{ url, @errorName(err) },
     );
 
     var client = std.http.Client{ .allocator = allocator };
     defer client.deinit();
 
     client.initDefaultProxies(allocator) catch |err| return .{ .err = std.fmt.allocPrint(
-        allocator, "failed to query the HTTP proxy settings with {s}", .{ @errorName(err) }
+        allocator,
+        "failed to query the HTTP proxy settings with {s}",
+        .{@errorName(err)},
     ) catch |e| oom(e) };
 
     var header_buffer: [4096]u8 = undefined;
@@ -67,16 +70,22 @@ fn download(allocator: Allocator, url: []const u8, writer: anytype) DownloadResu
         .server_header_buffer = &header_buffer,
         .keep_alive = false,
     }) catch |err| return .{ .err = std.fmt.allocPrint(
-        allocator, "failed to connect to the HTTP server with {s}", .{ @errorName(err) }
+        allocator,
+        "failed to connect to the HTTP server with {s}",
+        .{@errorName(err)},
     ) catch |e| oom(e) };
 
     defer request.deinit();
 
     request.send() catch |err| return .{ .err = std.fmt.allocPrint(
-        allocator, "failed to send the HTTP request with {s}", .{ @errorName(err) }
+        allocator,
+        "failed to send the HTTP request with {s}",
+        .{@errorName(err)},
     ) catch |e| oom(e) };
     request.wait() catch |err| return .{ .err = std.fmt.allocPrint(
-        allocator, "failed to read the HTTP response headers with {s}", .{ @errorName(err) }
+        allocator,
+        "failed to read the HTTP response headers with {s}",
+        .{@errorName(err)},
     ) catch |e| oom(e) };
 
     if (request.response.status != .ok) return .{ .err = std.fmt.allocPrint(
@@ -90,12 +99,17 @@ fn download(allocator: Allocator, url: []const u8, writer: anytype) DownloadResu
     var buf: [std.mem.page_size]u8 = undefined;
     while (true) {
         const len = request.reader().read(&buf) catch |err| return .{ .err = std.fmt.allocPrint(
-            allocator, "failed to read the HTTP response body with {s}'", .{ @errorName(err) }
+            allocator,
+            "failed to read the HTTP response body with {s}'",
+            .{@errorName(err)},
         ) catch |e| oom(e) };
-        if (len == 0)
-            return .ok;
+
+        if (len == 0) return .ok;
+
         writer.writeAll(buf[0..len]) catch |err| return .{ .err = std.fmt.allocPrint(
-            allocator, "failed to write the HTTP response body with {s}'", .{ @errorName(err) }
+            allocator,
+            "failed to write the HTTP response body with {s}'",
+            .{@errorName(err)},
         ) catch |e| oom(e) };
     }
 }
@@ -103,7 +117,6 @@ fn download(allocator: Allocator, url: []const u8, writer: anytype) DownloadResu
 const DownloadStringResult = union(enum) {
     ok: []u8,
     err: []u8,
-
 };
 fn downloadToString(allocator: Allocator, url: []const u8) DownloadStringResult {
     var response_array_list = ArrayList(u8).initCapacity(allocator, 20 * 1024) catch |e| oom(e); // 20 KB (modify if response is expected to be bigger)
@@ -457,7 +470,7 @@ fn fetchDownloadIndex(allocator: Allocator) !DownloadIndex {
     const text = switch (downloadToString(allocator, download_index_url)) {
         .ok => |text| text,
         .err => |err| {
-            std.log.err("download '{s}' failed: {s}", .{download_index_url, err});
+            std.log.err("download '{s}' failed: {s}", .{ download_index_url, err });
             return error.AlreadyReported;
         },
     };
@@ -513,7 +526,7 @@ pub fn loggyUpdateSymlink(target_path: []const u8, sym_link_path: []const u8, fl
         error.NotLink => {
             std.debug.print(
                 "unable to update/overwrite the 'zig' PATH symlink, the file '{s}' already exists and is not a symlink\n",
-                .{ sym_link_path},
+                .{sym_link_path},
             );
             std.process.exit(1);
         },
@@ -932,7 +945,7 @@ fn createExeLink(link_target: []const u8, path_link: []const u8) !void {
         error.IsDir => {
             std.debug.print(
                 "unable to create the exe link, the path '{s}' is a directory\n",
-                .{ path_link},
+                .{path_link},
             );
             std.process.exit(1);
         },
@@ -985,7 +998,7 @@ fn installCompiler(allocator: Allocator, compiler_dir: []const u8, url: []const 
         }) {
             .ok => {},
             .err => |err| {
-                std.log.err("download '{s}' failed: {s}", .{url, err});
+                std.log.err("download '{s}' failed: {s}", .{ url, err });
                 // this removes the installing dir if the http request fails so we dont have random directories
                 try loggyDeleteTreeAbsolute(installing_dir);
                 return error.AlreadyReported;

--- a/zigup.zig
+++ b/zigup.zig
@@ -569,9 +569,22 @@ fn listCompilers(allocator: Allocator) !void {
     {
         var it = install_dir.iterate();
         while (try it.next()) |entry| {
-            if (entry.kind != .directory)
+            var target = entry.name;
+            var link_buffer: [std.fs.max_path_bytes]u8 = undefined;
+            var real_buffer: [std.fs.max_path_bytes]u8 = undefined;
+            if (entry.kind == .sym_link) {
+                const link_path = install_dir.readLink(entry.name, &link_buffer) catch continue;
+                const real_path = install_dir.realpath(link_path, &real_buffer) catch continue;
+                const relative = try std.fs.path.relative(allocator, install_dir_string, real_path);
+                defer allocator.free(relative);
+                if (std.fs.path.isAbsolute(relative) or std.mem.startsWith(u8, relative, "..")) {
+                    continue;
+                }
+                install_dir.access(link_path, .{}) catch continue;
+                target = link_path;
+            } else if (entry.kind != .directory)
                 continue;
-            if (std.mem.endsWith(u8, entry.name, ".installing"))
+            if (std.mem.endsWith(u8, target, ".installing"))
                 continue;
             try stdout.print("{s}\n", .{entry.name});
         }

--- a/zip.zig
+++ b/zip.zig
@@ -17,7 +17,10 @@ fn usage() noreturn {
 }
 
 var windows_args_arena = if (builtin.os.tag == .windows)
-    std.heap.ArenaAllocator.init(std.heap.page_allocator) else struct{}{};
+    std.heap.ArenaAllocator.init(std.heap.page_allocator)
+else
+    struct {}{};
+
 pub fn cmdlineArgs() [][*:0]u8 {
     if (builtin.os.tag == .windows) {
         const slices = std.process.argsAlloc(windows_args_arena.allocator()) catch |err| switch (err) {
@@ -31,7 +34,7 @@ pub fn cmdlineArgs() [][*:0]u8 {
         }
         return args;
     }
-    return std.os.argv.ptr[1 .. std.os.argv.len];
+    return std.os.argv.ptr[1..std.os.argv.len];
 }
 
 pub fn main() !void {
@@ -52,7 +55,7 @@ pub fn main() !void {
                 fatal("unknown cmdline option '{s}'", .{arg});
             }
         }
-        break :blk cmd_args[0 .. non_option_len];
+        break :blk cmd_args[0..non_option_len];
     };
 
     if (cmd_args.len < 2) usage();
@@ -87,7 +90,8 @@ pub fn main() !void {
             .whiteout,
             .door,
             .event_port,
-            .unknown => fatal("file '{s}' is an unsupported type {s}", .{path, @tagName(stat.kind)}),
+            .unknown,
+            => fatal("file '{s}' is an unsupported type {s}", .{ path, @tagName(stat.kind) }),
         }
     }
 
@@ -96,7 +100,7 @@ pub fn main() !void {
 
     {
         const zip_file = std.fs.cwd().createFile(zip_file_arg, .{}) catch |err|
-            fatal("create file '{s}' failed: {s}", .{zip_file_arg, @errorName(err)});
+            fatal("create file '{s}' failed: {s}", .{ zip_file_arg, @errorName(err) });
         defer zip_file.close();
         try writeZip(zip_file, file_entries.items, store);
     }
@@ -104,7 +108,7 @@ pub fn main() !void {
     // go fix up the local file headers
     {
         const zip_file = std.fs.cwd().openFile(zip_file_arg, .{ .mode = .read_write }) catch |err|
-            fatal("open file '{s}' failed: {s}", .{zip_file_arg, @errorName(err)});
+            fatal("open file '{s}' failed: {s}", .{ zip_file_arg, @errorName(err) });
         defer zip_file.close();
         for (file_entries.items, 0..) |file, i| {
             try zip_file.seekTo(store[i].file_offset);
@@ -156,7 +160,7 @@ fn writeZip(
                 var full_rw_buf: [std.mem.page_size]u8 = undefined;
                 var remaining = file_entry.size;
                 while (remaining > 0) {
-                    const buf = full_rw_buf[0 .. @min(remaining, full_rw_buf.len)];
+                    const buf = full_rw_buf[0..@min(remaining, full_rw_buf.len)];
                     const read_len = try file.reader().read(buf);
                     std.debug.assert(read_len == buf.len);
                     hash.update(buf);
@@ -219,7 +223,6 @@ pub fn Crc32Reader(comptime ReaderType: type) type {
         }
     };
 }
-
 
 fn isBadFilename(filename: []const u8) bool {
     if (std.mem.indexOfScalar(u8, filename, '\\')) |_|


### PR DESCRIPTION
This PR makes `zigup list` include symlinks to compilers in the install directory display in the list of installed compilers. This is useful as it is possible to use these symlinks as the `COMPILER_NAME` in `zigup default COMPILER_NAME`. Currently the only symlink created by zigup is one for `master`, but this PR would also support a user who wants to make custom symlinks to name particular compilers.

This feature will be particularly helpful if/when mach nominated versions are supported, as all of the nominated versions should be referenced via a link.