### PR TITLE
Make zigup configurable through an enviroment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zigup
 
-Fork of [https://marler8997.github.io/zigup](zigup) which aims to make it easier to download and manage zig version. This fork is based on how rustup works.
+Fork of [zigup](https://marler8997.github.io/zigup) which aims to make it easier to download and manage zig versions. This fork is based on how [rustup](https://rustup.rs/) works.
 
 # How to Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zigup
 
-Download and manage zig compilers.
+Fork of [https://marler8997.github.io/zigup](zigup) which aims to make it easier to download and manage zig version. This fork is based on how rustup works.
 
 # How to Install
 
@@ -9,6 +9,17 @@ Go to https://marler8997.github.io/zigup and select your OS/Arch to get a downlo
 Otherwise, you can manually find and download/extract the applicable archive from [Releases](https://github.com/marler8997/zigup/releases). It will contain a single static binary named `zigup`, unless you're on Windows in which case it's 2 files, `zigup.exe` and `zigup.pdb`.
 
 # Usage
+
+```sh
+$ zig version
+0.14.0-dev.2198+e5f5229fd
+$ zigup fetch 0.13.0
+...
+$ zigup default 0.13.0
+...
+$ zig version
+0.13.0
+```
 
 ```
 # fetch a compiler and set it as the default

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zigup
 
-Fork of [zigup](https://marler8997.github.io/zigup) which aims to make it easier to download and manage zig versions. This fork is based on how [rustup](https://rustup.rs/) works.
+Download and manage zig compilers.
 
 # How to Install
 
@@ -11,17 +11,6 @@ Otherwise, you can manually find and download/extract the applicable archive fro
 # Usage
 
 ```sh
-$ zig version
-0.14.0-dev.2198+e5f5229fd
-$ zigup fetch 0.13.0
-...
-$ zigup default 0.13.0
-...
-$ zig version
-0.13.0
-```
-
-```
 # fetch a compiler and set it as the default
 zigup <version>
 zigup master
@@ -36,6 +25,12 @@ zigup default
 
 # set the default compiler
 zigup default <version>
+
+# set the default compiler from a path
+zigup default zig/build
+
+# unset the default compiler (for using a global installation)
+zigup undefine
 
 # list the installed compiler versions
 zigup list
@@ -52,11 +47,12 @@ zigup run <version> <args>...
 
 # How the compilers are managed
 
-zigup stores each compiler in a global "install directory" in a versioned subdirectory.  On posix systems the "install directory" is `$HOME/zig` and on windows the install directory will be a directory named "zig" in the same directory as the "zigup.exe".
+`zigup` stores each compiler in `$ZIGUP_INSTALL_DIR`, in a versioned subdirectory. The default install directory is `$HOME/.zigup/cache`.
 
-zigup makes the zig program available by creating an entry in a directory that occurs in the `PATH` environment variable.  On posix systems this entry is a symlink to one of the `zig` executables in the install directory.  On windows this is an executable that forwards invocations to one of the `zig` executables in the install directory.
+`zigup` makes the zig available by creating a symlink at `$ZIGUP_INSTALL_DIR/<version>` and `$ZIGUP_DIR/default` which points to the current active default compiler.
 
-Both the "install directory" and "path link" are configurable through command-line options `--install-dir` and `--path-link` respectively.
+Configuration on done during the first use of zigup and the generated environment is installed at `$ZIGUP_DIR/env`.
+
 # Building
 
 Run `zig build` to build, `zig build test` to test and install with:
@@ -67,11 +63,12 @@ cp zig-out/bin/zigup BIN_PATH
 
 # Building Zigup
 
-Zigup is currently built/tested using zig 0.12.0.
+Zigup is currently built/tested using zig 0.13.0+.
 
 # TODO
 
-* set/remove compiler in current environment without overriding the system-wide version.
+[ ] - Download to memory.
+[ ] - Use `std.tar` (Unix)
 
 # Dependencies
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Zigup is currently built/tested using zig 0.13.0+.
 
 # TODO
 
-[ ] - Download to memory.
-[ ] - Use `std.tar` (Unix)
+- [ ] Download to memory
+- [ ] Use `std.tar` (Unix)
 
 # Dependencies
 

--- a/zigup.zig
+++ b/zigup.zig
@@ -389,7 +389,7 @@ pub fn zigup() !u8 {
     // TODO: If the user removes `config.path` zigup will work while the shell
     // is up, we should assert that the env exist, possible creating it if it's
     // missing. This has the bonus of allowing the user to skip configuration
-    // with `ZIGUP_PATH="..." zigup ...`.
+    // dialog with `ZIGUP_PATH="..." zigup ...`.
 
     var args = if (args_array.len == 0) args_array else args_array[1..];
     // parse common options

--- a/zigup.zig
+++ b/zigup.zig
@@ -169,9 +169,10 @@ fn help() void {
         \\  zigup VERSION                 download and set VERSION compiler as default
         \\  zigup fetch VERSION           download VERSION compiler
         \\  zigup default [VERSION]       get or set the default compiler
+        \\  zigup undefine                unset the default compiler
         \\  zigup list                    list installed compiler versions
         \\  zigup clean   [VERSION]       deletes the given compiler version, otherwise, cleans all compilers
-        \\                                that aren't the default, master, or marked to keep.
+        \\                                that aren't the default, master, or marked to keep
         \\  zigup keep VERSION            mark a compiler to be kept during clean
         \\  zigup run VERSION ARGS...     run the given VERSION of the compiler with the given ARGS...
         \\

--- a/zigup.zig
+++ b/zigup.zig
@@ -377,11 +377,21 @@ pub fn zigup() !u8 {
 
     const config = try readConfigFromEnv(allocator) orelse {
         try configure(allocator);
+        // NOTE: We could just make zigup work here, but we should assert that
+        // the user does the proper shell configuration. One way of doing this
+        // is to just do noting, which will cause zigup to "not work" until the
+        // shell environment is up
         return 0;
     };
 
+    // Assert that the dirs exist
     try makeDirIfMissing(config.path);
     try makeDirIfMissing(config.install_path);
+
+    // TODO: If the user removes `config.path` zigup will work while the shell
+    // is up, we should assert that the env exist, possible creating it if it's
+    // missing. This has the bonus of allowing the user to skip configuration
+    // with `ZIGUP_PATH="..." zigup ...`.
 
     var args = if (args_array.len == 0) args_array else args_array[1..];
     // parse common options

--- a/zigup.zig
+++ b/zigup.zig
@@ -5,6 +5,10 @@ const mem = std.mem;
 const ArrayList = std.ArrayList;
 const Allocator = mem.Allocator;
 
+pub const std_options = .{
+    .log_level = .info,
+};
+
 const fixdeletetree = @import("fixdeletetree.zig");
 
 const arch = switch (builtin.cpu.arch) {

--- a/zigup.zig
+++ b/zigup.zig
@@ -436,9 +436,8 @@ pub fn zigup() !u8 {
             return 1;
         }
 
-        try unsetDefaultCompiler(allocator, &config);
+        try unsetDefaultCompiler(&config);
 
-        if (isBash()) logw("Use `hash -r` to reset the command location cache.", .{});
         return 0;
     }
     if (std.mem.eql(u8, "fetch", args[0])) {
@@ -856,10 +855,13 @@ fn printDefaultCompiler(allocator: Allocator, config: *const ZigupConfig) !void 
     }
 }
 
-fn unsetDefaultCompiler(allocator: Allocator, config: *const ZigupConfig) !void {
-    const link_path = try std.fmt.allocPrint(allocator, "{s}/default", .{config.path});
+fn unsetDefaultCompiler(config: *const ZigupConfig) !void {
+    std.posix.unlink(config.default_path) catch |err|
+        return if (err == error.FileNotFound) logw("no default compiler is set", .{}) else err;
 
-    try std.posix.unlink(link_path);
+    if (isBash()) {
+        logw("Use `hash -r` to reset the command location cache.", .{});
+    }
 }
 
 fn setDefaultCompiler(allocator: Allocator, compiler_dir: []const u8, config: *const ZigupConfig, verify_exists: bool) !void {

--- a/zigup.zig
+++ b/zigup.zig
@@ -31,6 +31,8 @@ var global_optional_path_link: ?[]const u8 = null;
 
 var global_enable_log = true;
 
+var verbose = false;
+
 inline fn fix_format_string(comptime fmt: []const u8) []const u8 {
     if (builtin.os.tag == .windows) {
         // Not sure what is going on here, or why they are doing this on
@@ -46,10 +48,7 @@ inline fn fix_format_string(comptime fmt: []const u8) []const u8 {
 }
 
 inline fn logi(comptime fmt: []const u8, args: anytype) void {
-    // TODO: `--verbose` option!?
-    if (builtin.mode == std.builtin.OptimizeMode.Debug) {
-        std.log.info(fix_format_string(fmt), args);
-    }
+    if (verbose) std.log.info(fix_format_string(fmt), args);
 }
 
 inline fn loge(comptime fmt: []const u8, args: anytype) void {
@@ -396,7 +395,6 @@ pub fn zigup() !u8 {
 
     var args = if (args_array.len == 0) args_array else args_array[1..];
     // parse common options
-    //
     {
         var i: usize = 0;
         var newlen: usize = 0;
@@ -415,6 +413,8 @@ pub fn zigup() !u8 {
             } else if (std.mem.eql(u8, "-h", arg) or std.mem.eql(u8, "--help", arg)) {
                 help();
                 return 0;
+            } else if (std.mem.eql(u8, "-v", arg) or std.mem.eql(u8, "--verbose", arg)) {
+                verbose = true;
             } else {
                 if (newlen == 0 and std.mem.eql(u8, "run", arg)) {
                     return try runCompiler(allocator, &config, args[i + 1 ..]);

--- a/zigup.zig
+++ b/zigup.zig
@@ -319,6 +319,7 @@ const shellEnvFmt =
     \\        export PATH="$ZIGUP_DIR/default:$PATH"
     \\        ;;
     \\esac
+    \\
 ;
 
 const sourceEnvFmt =

--- a/zigup.zig
+++ b/zigup.zig
@@ -5,7 +5,7 @@ const mem = std.mem;
 const ArrayList = std.ArrayList;
 const Allocator = mem.Allocator;
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     .log_level = .info,
 };
 
@@ -179,10 +179,7 @@ fn help() void {
         \\  zigup fetch-index             download and print the download index json
         \\
         \\Common Options:
-        \\  --install-dir DIR             override the default install location
-        \\  --path-link PATH              path to the `zig` symlink that points to the default compiler
-        \\                                this will typically be a file path within a PATH directory so
-        \\                                that the user can just run `zig`
+        \\  --verbose | -v                output verbose information
         \\
     ) catch unreachable;
 }


### PR DESCRIPTION
This PR adds a few things and ideas:
* Makes `zigup` configurable through an environment, defined at `$ZIGUP_DIR/env`. Inline with #113;
* Allows `zigup` to auto-configure itself (with minimal action required by the user);
* Replaces `--install-dir` and `--path-link` with `$ZIGUP_INSTALL_DIR` and `$ZIGUP_DIR`. Inline with #148;
* Rework how the default compiler is set (needs testing on Windows), fixes #69;
* Allows `zigup default` to set the default compiler from a path, i.e., `zigup default zig/build`;
* Adds `zigup undefine` to unset the current default compiler;
* Reworks logging and adds a flag, `-v` or `--verbose`, to enable verbose output;

Overall, this makes `zigup` work when installed globally (from a package manager); and allows persistent configuration. For now, only tested on Linux.