### PR TITLE
feat(Website): PowerShell and Homebrew command and cosmetic adjustments for readability/sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,18 @@ body {
 a { color: #eee }
 h1 { color:#eee }
 h2 { color:#eee }
-pre { font-family: courier new }
+section {
+    display: grid;
+    justify-items: center;
+    align-items: center;
+}
+code {
+    padding: 0.75em;
+    font-family: courier new;
+    text-align: left;
+    word-wrap: break-word;
+    background: #111;
+}
 
 #InstallDiv {
     margin:10px;
@@ -49,6 +60,18 @@ pre { font-family: courier new }
 .FilterButtonEnabled:hover {
   background:#3277e5;
 }
+
+.Commands {
+  display: grid;
+  gap: 1em;
+  grid-auto-rows: 5em;
+}
+.Commands div {
+  display: grid;
+  gap: 3em;
+  grid-template-columns: 10em 45em;
+}
+
 </style>
 <script>
 
@@ -77,7 +100,7 @@ function copyToClipboard(text) {
       return (
           '<div>' +
               '<button class="CopyButton" onclick="copyCommand(' + id + ')">Copy</button> ' +
-              '<pre style="display:inline-block" id="command' + id + '">' + cmd + '</pre>' +
+              '<code style="display:inline-block" id="command' + id + '">' + cmd + '</code>' +
           '</div>'
       );
   }
@@ -155,6 +178,7 @@ function copyToClipboard(text) {
           html += '<br/><h2 style="margin:15px"><a href="' + archive_url + '">' + basename + '</a></h2>';
 
           html += '<br/><h2>Command Line Install:</h2>';
+          html += "<section><div class='Commands'>";
           var ids = { next_id: 0 };
           if (include_curl) {
               html += generateCommandHtml(ids, 'curl -L ' + archive_url + ' | tar xz');
@@ -162,6 +186,7 @@ function copyToClipboard(text) {
           if (include_wget) {
               html += generateCommandHtml(ids, 'wget -O - ' + archive_url + ' | tar xz');
           }
+          html += "</div></section>";
       }
       get('InstallDiv').innerHTML = html;
   }

--- a/index.html
+++ b/index.html
@@ -146,11 +146,13 @@ function copyToClipboard(text) {
   var include_curl = true;
   var include_wget = true;
   var include_homebrew = false;
+  var include_powershell = false;
 
   function updateInstallDiv() {
       var arch_os = null;
       var archive_ext = null;
       include_homebrew = false;
+      include_powershell = false;
       if (current_os == OS_LINUX) {
           archive_ext = ".tar.gz";
           if (current_arch == ARCH_X86_64) {
@@ -169,6 +171,7 @@ function copyToClipboard(text) {
       } else if (current_os == OS_WINDOWS) {
           archive_ext = ".zip";
           if (current_arch == ARCH_X86_64) {
+              include_powershell = true;
               arch_os = "x86_64-windows";
           }
       }
@@ -191,6 +194,9 @@ function copyToClipboard(text) {
           }
           if (include_wget) {
               html += generateCommandHtml(ids, 'wget -O - ' + archive_url + ' | tar xz');
+          }
+          if (include_powershell) {
+              html += generateCommandHtml(ids, "Invoke-WebRequest -Uri " + archive_url + " -OutFile \"zigup-"  + arch_os + ".zip\"; Expand-Archive -Path \"zigup-" + arch_os + ".zip\" -DestinationPath \"zigup-" + version + "\"");
           }
           html += "</div></section>";
       }

--- a/index.html
+++ b/index.html
@@ -145,10 +145,12 @@ function copyToClipboard(text) {
   var current_arch = -1;
   var include_curl = true;
   var include_wget = true;
+  var include_homebrew = false;
 
   function updateInstallDiv() {
       var arch_os = null;
       var archive_ext = null;
+      include_homebrew = false;
       if (current_os == OS_LINUX) {
           archive_ext = ".tar.gz";
           if (current_arch == ARCH_X86_64) {
@@ -157,6 +159,7 @@ function copyToClipboard(text) {
               arch_os = "aarch64-linux";
           }
       } else if (current_os == OS_MACOS) {
+          include_homebrew = true;
           archive_ext = ".tar.gz";
           if (current_arch == ARCH_X86_64) {
               arch_os = "x86_64-macos";
@@ -180,6 +183,9 @@ function copyToClipboard(text) {
           html += '<br/><h2>Command Line Install:</h2>';
           html += "<section><div class='Commands'>";
           var ids = { next_id: 0 };
+          if (include_homebrew) {
+              html += generateCommandHtml(ids, "brew install zigup");
+          }
           if (include_curl) {
               html += generateCommandHtml(ids, 'curl -L ' + archive_url + ' | tar xz');
           }


### PR DESCRIPTION
I recently had to dust off a Windows machine and saw that zigup didn't have an equivalent PowerShell command. This PR adds a PowerShell command when Windows is selected. It also adjusts the UI so that this new item fits more gracefully.

New UI Adjustments:
![image](https://github.com/user-attachments/assets/427222de-bb55-4f93-a88a-4fbf0a3aa8f4)

Current UI:
![image](https://github.com/user-attachments/assets/f525533f-a32d-46ba-a869-be2b9bb8628e)
