### PR TITLE
set optimize mode and strip options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Download and manage zig compilers.
 
 Go to https://marler8997.github.io/zigup and select your OS/Arch to get a download link and/or instructions to install via the command-line.
 
-Otherwise, you can manually find and download/extract the applicable archive from [Releases](https://github.com/marler8997/zigup/releases). It will contain a single static binary named `zigup`, unless you're on Windows in which case it's 2 files, `zigup.exe` and `zigup.pdb`.
+Otherwise, you can manually find and download/extract the applicable archive from [Releases](https://github.com/marler8997/zigup/releases). It will contain a single static binary named `zigup`, unless you're on Windows in which case it's `zigup.exe`.
 
 # Usage
 

--- a/build.zig
+++ b/build.zig
@@ -173,7 +173,6 @@ fn makeCiArchiveStep(
         const zip = b.addRunArtifact(host_zip_exe);
         zip.addArg(out_zip_file);
         zip.addArg("zigup.exe");
-        zip.addArg("zigup.pdb");
         zip.cwd = .{ .cwd_relative = b.getInstallPath(
             exe_install.dest_dir.?,
             ".",

--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{});
+    const optimize = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseSafe });
 
     const zigup_exe_native = blk: {
         const exe = addZigupExe(b, target, optimize);
@@ -94,6 +94,7 @@ fn addZigupExe(
         .root_source_file = b.path("zigup.zig"),
         .target = target,
         .optimize = optimize,
+        .strip = true,
     });
 
     if (target.result.os.tag == .windows) {


### PR DESCRIPTION
# Changes
- Adds a `preferred_optimize_mode` to `zigup` binary;
- Adds a `strip = true` option to `zigup` binary;

# Result
These changes builds significantly smaller binary with no debug info (more suited to end users) when project is built with `zig build --release`.
![image](https://github.com/user-attachments/assets/6093eeec-6de3-4f9f-b3a9-1ca802bf2e21)
note: this image is in text form on issue #169.

# Todo
Fix GitHub Actions workflow to build and upload new files.

closes #169 