### PR TITLE
Synchronize the list of supported targets with ziglang.org tarballs.

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -20,13 +20,14 @@ jobs:
         with:
           name: zigup-archives
           path: |
-            zig-out/zigup-x86_64-linux.tar.gz
-            zig-out/zigup-x86_64-macos.tar.gz
-            zig-out/zigup-x86_64-windows.zip
             zig-out/zigup-aarch64-linux.tar.gz
             zig-out/zigup-aarch64-macos.tar.gz
             zig-out/zigup-aarch64-windows.zip
             zig-out/zigup-arm-linux.tar.gz
-            zig-out/zigup-riscv64-linux.tar.gz
-            zig-out/zigup-powerpc-linux.tar.gz
             zig-out/zigup-powerpc64le-linux.tar.gz
+            zig-out/zigup-riscv64-linux.tar.gz
+            zig-out/zigup-x86-linux.tar.gz
+            zig-out/zigup-x86-windows.tar.gz
+            zig-out/zigup-x86_64-linux.tar.gz
+            zig-out/zigup-x86_64-macos.tar.gz
+            zig-out/zigup-x86_64-windows.zip

--- a/build.zig
+++ b/build.zig
@@ -109,16 +109,17 @@ fn ci(
     host_zip_exe: *std.Build.Step.Compile,
 ) !void {
     const ci_targets = [_][]const u8{
-        "x86_64-linux",
-        "x86_64-macos",
-        "x86_64-windows",
         "aarch64-linux",
         "aarch64-macos",
         "aarch64-windows",
         "arm-linux",
-        "riscv64-linux",
-        "powerpc-linux",
         "powerpc64le-linux",
+        "riscv64-linux",
+        "x86-linux",
+        "x86-windows",
+        "x86_64-linux",
+        "x86_64-macos",
+        "x86_64-windows",
     };
 
     const make_archive_step = b.step("archive", "Create CI archives");

--- a/zigup.zig
+++ b/zigup.zig
@@ -8,18 +8,18 @@ const Allocator = mem.Allocator;
 const fixdeletetree = @import("fixdeletetree.zig");
 
 const arch = switch (builtin.cpu.arch) {
-    .x86_64 => "x86_64",
     .aarch64 => "aarch64",
     .arm => "armv7a",
-    .riscv64 => "riscv64",
     .powerpc64le => "powerpc64le",
-    .powerpc => "powerpc",
+    .riscv64 => "riscv64",
+    .x86 => "x86",
+    .x86_64 => "x86_64",
     else => @compileError("Unsupported CPU Architecture"),
 };
 const os = switch (builtin.os.tag) {
-    .windows => "windows",
     .linux => "linux",
     .macos => "macos",
+    .windows => "windows",
     else => @compileError("Unsupported OS"),
 };
 const url_platform = os ++ "-" ++ arch;


### PR DESCRIPTION
Added:

* ~`loongarch64-linux`~
* `x86-linux`
* `x86-windows`

Removed:

* `powerpc-linux`