### PR TITLE
Add `s390x-linux` support.

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -24,6 +24,7 @@ jobs:
             zig-out/zigup-arm-linux.tar.gz
             zig-out/zigup-powerpc64le-linux.tar.gz
             zig-out/zigup-riscv64-linux.tar.gz
+            zig-out/zigup-s390x-linux.tar.gz
             zig-out/zigup-x86-linux.tar.gz
             zig-out/zigup-x86-windows.tar.gz
             zig-out/zigup-x86_64-linux.tar.gz

--- a/build.zig
+++ b/build.zig
@@ -115,6 +115,7 @@ fn ci(
         "arm-linux",
         "powerpc64le-linux",
         "riscv64-linux",
+        "s390x-linux",
         "x86-linux",
         "x86-windows",
         "x86_64-linux",

--- a/zigup.zig
+++ b/zigup.zig
@@ -12,6 +12,7 @@ const arch = switch (builtin.cpu.arch) {
     .arm => "armv7a",
     .powerpc64le => "powerpc64le",
     .riscv64 => "riscv64",
+    .s390x => "s390x",
     .x86 => "x86",
     .x86_64 => "x86_64",
     else => @compileError("Unsupported CPU Architecture"),


### PR DESCRIPTION
This appeared in Zig 0.14.1.