### PR TITLE
Add handling for FreeBSD and NetBSD.

### DIFF
--- a/zigup.zig
+++ b/zigup.zig
@@ -10,6 +10,7 @@ const fixdeletetree = @import("fixdeletetree.zig");
 const arch = switch (builtin.cpu.arch) {
     .aarch64 => "aarch64",
     .arm => "armv7a",
+    .powerpc64 => "powerpc64",
     .powerpc64le => "powerpc64le",
     .riscv64 => "riscv64",
     .s390x => "s390x",
@@ -18,8 +19,10 @@ const arch = switch (builtin.cpu.arch) {
     else => @compileError("Unsupported CPU Architecture"),
 };
 const os = switch (builtin.os.tag) {
+    .freebsd => "freebsd",
     .linux => "linux",
     .macos => "macos",
+    .netbsd => "netbsd",
     .windows => "windows",
     else => @compileError("Unsupported OS"),
 };


### PR DESCRIPTION
No CI builds for these yet as that depends on Zig 0.15.0.